### PR TITLE
fix: replace undeployed message-queues link in CQRS post

### DIFF
--- a/_posts/2025-03-04-cqrs-command-query-responsibility-segregation.md
+++ b/_posts/2025-03-04-cqrs-command-query-responsibility-segregation.md
@@ -225,4 +225,4 @@ Do not rewrite everything. Identify one bottleneck. That slow report. That heavy
 
 The pattern is simple. Separate reads from writes. Start with the simplest implementation that solves your problem. Add complexity only when the benefits clearly outweigh the costs.
 
-> **Related posts**: [Message Queues](/posts/message-queues/), [Latency and Throughput](/posts/latency-and-throughput/)
+> **Related posts**: [Apache Kafka](/posts/apache-kafka/), [Latency and Throughput](/posts/latency-and-throughput/)


### PR DESCRIPTION
The message-queues post was never committed, so the link caused htmlproofer to fail. Replaced with Apache Kafka which is committed and referenced in the Level 4 section of the post.